### PR TITLE
run UI tests in multiple browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,19 @@ matrix:
     - php: 5.6
       env: DB=sqlite;TC=carddav-old-endpoint
     - php: 5.6
-      env: DB=pgsql;TC=selenium;TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="48.0" PLATFORM=Linux TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" PLATFORM="Windows 10" TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" PLATFORM="Windows 10" TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="26" PLATFORM="Windows 10" TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" PLATFORM="Windows 10" TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="14.0" PLATFORM="Windows 10" TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" PLATFORM="Windows 7" TEST_DAV=0
     - php: 5.6
       env: DB=sqlite;TC=syntax;TEST_DAV=0
     - php: 7.0

--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -12,6 +12,7 @@ then
 else
 	BASE_URL="http://$SRV_HOST_NAME:$SRV_HOST_PORT/$SRV_HOST_URL"
 fi
+echo "Running tests on '$BROWSER' ($BROWSER_VERSION) on $PLATFORM"
+export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": "'$BROWSER'", "base_url" : "'$BASE_URL'","selenium2":{"capabilities": {"browser": "'$BROWSER'", "version": "'$BROWSER_VERSION'", "platform": "'$PLATFORM'"}, "wd_host":"http://'$SAUCE_USERNAME:$SAUCE_ACCESS_KEY'@localhost:4445/wd/hub"}}}}' 
 
-export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "'$BASE_URL'","selenium2":{"wd_host":"http://'$SAUCE_USERNAME:$SAUCE_ACCESS_KEY'@localhost:4445/wd/hub"}}}}'
 lib/composer/bin/behat -c tests/ui/config/behat.yml

--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -15,4 +15,9 @@ fi
 echo "Running tests on '$BROWSER' ($BROWSER_VERSION) on $PLATFORM"
 export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": "'$BROWSER'", "base_url" : "'$BASE_URL'","selenium2":{"capabilities": {"browser": "'$BROWSER'", "version": "'$BROWSER_VERSION'", "platform": "'$PLATFORM'"}, "wd_host":"http://'$SAUCE_USERNAME:$SAUCE_ACCESS_KEY'@localhost:4445/wd/hub"}}}}' 
 
-lib/composer/bin/behat -c tests/ui/config/behat.yml
+if [ "$BROWSER" == "internet explorer" ]
+then
+	lib/composer/bin/behat -c tests/ui/config/behat.yml --tags '~@skipOnIE'
+else
+	lib/composer/bin/behat -c tests/ui/config/behat.yml
+fi

--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -5,15 +5,18 @@
 # @author Artur Neumann
 # @copyright 2017 Artur Neumann info@individual-it.net
 #
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
 
-if [ "$SRV_HOST_PORT" == "80" ]
+if [ "$SRV_HOST_PORT" == "80" ] || [ -z "$SRV_HOST_PORT" ]
 then
 	BASE_URL="http://$SRV_HOST_NAME/$SRV_HOST_URL"
 else
 	BASE_URL="http://$SRV_HOST_NAME:$SRV_HOST_PORT/$SRV_HOST_URL"
 fi
 echo "Running tests on '$BROWSER' ($BROWSER_VERSION) on $PLATFORM"
-export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": "'$BROWSER'", "base_url" : "'$BASE_URL'","selenium2":{"capabilities": {"browser": "'$BROWSER'", "version": "'$BROWSER_VERSION'", "platform": "'$PLATFORM'"}, "wd_host":"http://'$SAUCE_USERNAME:$SAUCE_ACCESS_KEY'@localhost:4445/wd/hub"}}}}' 
+export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": "'$BROWSER'", "base_url" : "'$BASE_URL'","selenium2":{"capabilities": {"browser": "'$BROWSER'", "version": "'$BROWSER_VERSION'", "platform": "'$PLATFORM'", "name": "'$TRAVIS_REPO_SLUG' - '$TRAVIS_JOB_NUMBER'"}, "wd_host":"http://'$SAUCE_USERNAME:$SAUCE_ACCESS_KEY'@localhost:4445/wd/hub"}}}}' 
 
 if [ "$BROWSER" == "internet explorer" ]
 then
@@ -21,3 +24,16 @@ then
 else
 	lib/composer/bin/behat -c tests/ui/config/behat.yml
 fi
+
+if [ "$?" == "0" ]
+then
+	PASSED=true
+else
+	PASSED=false
+fi
+
+SAUCELABS_SESSIONID=`cat /tmp/saucelabs_sessionid`
+curl -X PUT -s -d "{\"passed\": $PASSED}" -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY https://saucelabs.com/rest/v1/$SAUCE_USERNAME/jobs/$SAUCELABS_SESSIONID
+
+printf "\n${RED}SAUCELABS RESULTS:${BLUE} https://saucelabs.com/jobs/$SAUCELABS_SESSIONID\n${NC}"
+

--- a/tests/ui/config/behat.yml
+++ b/tests/ui/config/behat.yml
@@ -2,10 +2,8 @@ default:
   autoload:
     '': %paths.base%/../features/bootstrap
   extensions:
-    Behat\MinkExtension:
-      browser_name: 'chrome'
     SensioLabs\Behat\PageObjectExtension: ~
-    
+
   suites:
     default:
       paths:
@@ -16,5 +14,3 @@ default:
         - UsersContext:
         - FilesContext:
         - PersonalSecuritySettingsContext:
-
-

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -21,6 +21,7 @@
 */
 
 use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\OwncloudPage;
 use Page\LoginPage;
@@ -59,4 +60,18 @@ class FeatureContext extends RawMinkContext implements Context
 		);
 	}
 	
+	/** @BeforeScenario */
+	public function setUpSuite(BeforeScenarioScope $scope)
+	{
+		$jobId = $this->getSessionId($scope);
+		file_put_contents("/tmp/saucelabs_sessionid", $jobId);
+	}
+	
+	public function getSessionId(BeforeScenarioScope $scope)
+	{
+		$url = $this->getSession()->getDriver()->getWebDriverSession()->getUrl();
+		$parts = explode('/', $url);
+		$sessionId = array_pop($parts);
+		return $sessionId;
+	}
 }

--- a/tests/ui/features/files.feature
+++ b/tests/ui/features/files.feature
@@ -1,6 +1,6 @@
 Feature: files
 
-	@AdminLogin
+	@AdminLogin @skipOnIE
 	Scenario: scroll fileactionsmenu into view
 		Given I am on the files page
 		And the list of files/folders does not fit in one browser page


### PR DESCRIPTION
This took a little bit longer that I've expected.
The first problem, and that took me a while to figure out, was the fact that the setting of env. variables does not work as expected in travis when separating them by a semicolon. They were somehow not correctly set. Need to separate them by a space (according to travis documentation)

**What tests are run now:**

- Chrome 48 on Linux, the newest Chrome that Saucelabs supports on Linux

- latest Chrome on Windows 10 (currently 57)

- latest-1 Chrome on Windows 10 (currently 56)

- oldest available Chrome (26) on Windows 10, as oC [claims to run on Chrome 18+ ](https://doc.owncloud.com/server/10.0/admin_manual/installation/system_requirements.html#web-browser)

- Firefox 47 on Windows 10 
webdriver for current Firefox is actually not ready, so we need to test on 47.0. see https://github.com/SeleniumHQ/selenium/issues/3693 & https://stackoverflow.com/questions/38746148/behat-mink-force-selenium-driver-to-use-chrome-instead-of-firefox#38764599

- oldest available Firefox (14) on Windows 10, as oC [claims to run on FF 14+ ](https://doc.owncloud.com/server/10.0/admin_manual/installation/system_requirements.html#web-browser)

- IE 11 on Windows 7
IE has a problem with one test (some JS problem) Notice: Undefined index: top in ... /tests/ui/features/bootstrap/FilesContext.php line 70

@phil-davis please review