### PR TITLE
don't throw exception if usr/grp couldn't be deleted in AfterScenario

### DIFF
--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -396,8 +396,8 @@ trait BasicStructure {
 			);
 			
 			if ($result->getStatusCode() !== 200) {
-				throw new Exception(
-					"could not delete user. "
+				error_log(
+					"INFORMATION: could not delete user. '" . $user . "'"
 					. $result->getStatusCode() . " " . $result->getBody()
 				);
 			}
@@ -412,8 +412,8 @@ trait BasicStructure {
 			);
 			
 			if ($result->getStatusCode() !== 200) {
-				throw new Exception(
-					"could not delete group. "
+				error_log(
+					"INFORMATION: could not delete group. '" . $group . "'"
 					. $result->getStatusCode() . " " . $result->getBody()
 				);
 			}


### PR DESCRIPTION
if a user or group could not be deleted in the tear-down phase of a test, do not throw an exception (test fails) but only show an info message