### PR TITLE
make waitForOutstandingAjaxCalls also wait for non-jQuery XHR

### DIFF
--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -267,22 +267,13 @@ class FilesPage extends FilesPageBasic {
 		$toMoveFileRow = $this->findFileRowByName($name, $session);
 		$destinationFileRow = $this->findFileRowByName($destination, $session);
 
-		$session->executeScript(
-			'
-			jQuery.countXHRRequests = 0;
-			(function(open) {
-				XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
-					jQuery.countXHRRequests++;
-					open.call(this, method, url, async, user, pass);
-				};
-			})(XMLHttpRequest.prototype.open);
-			'
-		);
-
+		$this->initAjaxCounters($session);
+		$this->resetSumStartedAjaxRequests($session);
+		
 		for ($retryCounter = 0; $retryCounter < $maxRetries; $retryCounter++) {
 			$toMoveFileRow->findFileLink()->dragTo($destinationFileRow->findFileLink());
 			$this->waitForAjaxCallsToStartAndFinish($session);
-			$countXHRRequests = $session->evaluateScript("jQuery.countXHRRequests");
+			$countXHRRequests = $this->getSumStartedAjaxRequests($session);
 			if ($countXHRRequests === 0) {
 				error_log("Error while moving file");
 			} else {

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -360,6 +360,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 		Session $session,
 		$timeout_msec = LONGUIWAITTIMEOUTMILLISEC
 	) {
+		$this->initAjaxCounters($session);
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -324,33 +324,7 @@ class OwncloudPage extends Page {
 		Session $session,
 		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
-		$activeAjaxCountSet = $session->evaluateScript(
-			"(typeof window.activeAjaxCount === 'undefined')"
-		);
-		if ($activeAjaxCountSet === true) {
-			$session->executeScript(
-				'
-				window.activeAjaxCount = 0;
-				function isAllXhrComplete(){
-					window.activeAjaxCount--;
-				}
-				
-				(function(open) {
-					XMLHttpRequest.prototype.open = function() {
-						this.addEventListener("load", isAllXhrComplete);
-						return open.apply(this, arguments);
-					};
-				})(XMLHttpRequest.prototype.open);
-							
-				(function(send) {
-					XMLHttpRequest.prototype.send = function () {
-						window.activeAjaxCount++;
-						return send.apply(this, arguments);
-					};
-				})(XMLHttpRequest.prototype.send);
-				'
-			);
-		}
+		$this->initAjaxCounters($session);
 		$timeout_msec = (int) $timeout_msec;
 		if ($timeout_msec <= 0) {
 			throw new \InvalidArgumentException("negative or zero timeout");
@@ -399,7 +373,9 @@ class OwncloudPage extends Page {
 	 * @param int $timeout_msec
 	 * @return void
 	 */
-	public function waitForAjaxCallsToStart(Session $session, $timeout_msec = 1000) {
+	public function waitForAjaxCallsToStart(
+		Session $session, $timeout_msec = 1000
+	) {
 		$timeout_msec = (int) $timeout_msec;
 		if ($timeout_msec <= 0) {
 			throw new \InvalidArgumentException("negative or zero timeout");
@@ -407,7 +383,20 @@ class OwncloudPage extends Page {
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
-			if ((int) $session->evaluateScript("jQuery.active") > 0) {
+			$activeAjax = $session->evaluateScript(
+				'
+					var result = 0;
+					if (typeof window.activeAjaxCount === "number") {
+						result = result + window.activeAjaxCount;
+					}
+					if (typeof jQuery.active === "number") {
+						result = result + jQuery.active;
+					}
+					return result;
+				'
+			);
+			$activeAjax = $session->evaluateScript("jQuery.active");
+			if ((int) $activeAjax > 0) {
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
@@ -433,6 +422,95 @@ class OwncloudPage extends Page {
 		$timeout_msec = $timeout_msec - (($end - $start) * 1000);
 		$timeout_msec = max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
 		$this->waitForOutstandingAjaxCalls($session, $timeout_msec);
+	}
+
+	/**
+	 * creates wrappers around XHR requests
+	 * counts active requests in "window.activeAjaxCount"
+	 * counts the sum of ajax requests in window.sumStartedAjaxRequests
+	 * 
+	 * @param Session $session
+	 * @see resetSumStartedAjaxRequests()
+	 * @see getSumStartedAjaxRequests()
+	 * @return void
+	 */
+	public function initAjaxCounters(
+		Session $session
+	) {
+		$activeAjaxCountIsUndefined = $session->evaluateScript(
+			"(typeof window.activeAjaxCount === 'undefined')"
+		);
+		
+		//only overwrite the send and open functions once
+		if ($activeAjaxCountIsUndefined === true) {
+			$session->executeScript(
+				'
+				window.sumStartedAjaxRequests = 0;
+				window.activeAjaxCount = 0;
+				function isAllXhrComplete(){
+					window.activeAjaxCount--;
+				}
+				
+				(function(open) {
+					XMLHttpRequest.prototype.open = function() {
+						this.addEventListener("load", isAllXhrComplete);
+						return open.apply(this, arguments);
+					};
+				})(XMLHttpRequest.prototype.open);
+				
+				(function(send) {
+					XMLHttpRequest.prototype.send = function () {
+						window.activeAjaxCount++;
+						window.sumStartedAjaxRequests++;
+						return send.apply(this, arguments);
+					};
+				})(XMLHttpRequest.prototype.send);
+				'
+			);
+		}
+	}
+
+	/**
+	 * reset the sum ajax counter so that every function can start counting from 0
+	 * 
+	 * @param Session $session
+	 * @see initAjaxCounters()
+	 * @return void
+	 */
+	public function resetSumStartedAjaxRequests(Session $session) {
+		$this->assertSumStartedAjaxRequestsIsDefined($session);
+		$session->executeScript('window.sumStartedAjaxRequests = 0;');
+	}
+
+	/**
+	 * gets the sum of all started Ajax requests
+	 * 
+	 * @param Session $session
+	 * @see initAjaxCounters()
+	 * @return int
+	 */
+	public function getSumStartedAjaxRequests(Session $session) {
+		$this->assertSumStartedAjaxRequestsIsDefined($session);
+		return (int) $session->evaluateScript("window.sumStartedAjaxRequests");
+	}
+
+	/**
+	 * 
+	 * @param Session $session
+	 * @see initAjaxCounters()
+	 * @throws \Exception
+	 * @return void
+	 */
+	private function assertSumStartedAjaxRequestsIsDefined(Session $session) {
+		$sumStartedAjaxRequestsIsUndefined = $session->evaluateScript(
+			"(typeof window.sumStartedAjaxRequests === 'undefined')"
+		);
+		if ($sumStartedAjaxRequestsIsUndefined === true) {
+			throw new \Exception(
+				"`window.sumStartedAjaxRequests` is undefined, " .
+				"call `initAjaxCounters()` first"
+			);
+		}
 	}
 
 	/**

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -384,7 +384,8 @@ class OwncloudPage extends Page {
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
 			$activeAjax = $session->evaluateScript(
-				'
+				'(
+				function () {
 					var result = 0;
 					if (typeof window.activeAjaxCount === "number") {
 						result = result + window.activeAjaxCount;
@@ -393,9 +394,9 @@ class OwncloudPage extends Page {
 						result = result + jQuery.active;
 					}
 					return result;
+				})()
 				'
 			);
-			$activeAjax = $session->evaluateScript("jQuery.active");
 			if ((int) $activeAjax > 0) {
 				break;
 			}


### PR DESCRIPTION
that should help the waiting for previews etc.
on computers with slow IO the previews do take time and if we try to delete/rename etc. the file where the preview is just created the test code breaks because the file is locked