### PR TITLE
Group name containing / can't be deleted

### DIFF
--- a/tests/ui/features/sharingInternalGroupsUsers/deleteGroupNameContainingBackslash.feature
+++ b/tests/ui/features/sharingInternalGroupsUsers/deleteGroupNameContainingBackslash.feature
@@ -1,0 +1,23 @@
+Feature: manage groups
+As an admin
+I want to manage groups
+So that access to resources can be controlled more effectively
+
+	Background:
+		Given a regular user exists but is not initialized
+		And I am logged in as admin
+		And I am on the users page
+
+	Scenario: delete group name containing "/"
+		And these groups exist:
+		|groupname     |
+		|test/test   |
+		|&@/?        |
+		|123/        |
+		And I am on the users page
+		When I delete these groups:
+		|groupname|
+		|test/test   |
+		|&@/?        |
+		|123/        |
+		And the users page is reloaded


### PR DESCRIPTION
Group name containing "/" can't be deleted but it shows temporary deleted during deleting time.when we refreshed the page then all groups containing "/" have been listed. 